### PR TITLE
Added 'ignoreRemoval' option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ gulp.task('deploy', function() {
 
 	Only trigger deployment on the following branch(es). Defaults to `master`.
 
+- `ignoreRemoval`
+
+  Based on `git add`'s `--ignore-removal` option. 
+  If `true`, files will not be removed from the remote repo. If `false`, files will be removed from the remote repo if they do not exist in the source files.
+  Defaults to `false`.
+
 - `verbose`
 
   Verbose mode. Will show output from all git commands run. Defaults to `false`.

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ module.exports = function(options) {
     repository: '',
     remoteBranch: 'master',
     branches: ['master'],
+    ignoreRemoval: false,
     verbose: false,
     debug: false
   }, options);
@@ -148,7 +149,12 @@ module.exports = function(options) {
         }
       },
       function gitAdd(callback) {
-        var cmdAdd = spawn('git', ['add', '--all', '.'], {cwd: repoPath});
+        var removalType = '--all';
+        if (options.ignoreRemoval){
+          removalType = '--ignore-removal';
+          if (options.verbose || options.debug) gutil.log(gutil.colors.magenta('git add: ignoring deleted files'));
+        }
+        var cmdAdd = spawn('git', ['add', removalType, '.'], {cwd: repoPath});
         cmdAdd.stderr.on('data', function(data) {
           if (options.verbose || options.debug) gutil.log(gutil.colors.magenta('git add: ') + data.toString().trim());
         });


### PR DESCRIPTION
Hey, I was using gulp-deploy-git in one of my projects and needed to use `git add`'s --ignore-removal option for the deployment process. I figured I'd submit the code I wrote in case anyone else wanted to use this option. 